### PR TITLE
Implement stage 1 api split and streaming

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-dom": "^18.2.0",
     "react-dotdotdot": "^1.3.1",
     "react-icons": "^4.11.0",
+    "react-markdown": "^9.0.0",
     "react-responsive-carousel": "^3.2.23",
     "react-router-dom": "^6.17.0",
     "react-scripts": "5.0.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,7 +13,7 @@ const router = createBrowserRouter(
     <Route path="/">
       <Route index element={<RecommendationBase />} loader={recommendationChatIdLoader}/>
       <Route path="/:id" element={<Recommendation/>}/>
-      <Route path="/project/dynamic" element={<DynamicProject />} />
+      <Route path="/project/dynamic/:id" element={<DynamicProject />} />
       <Route path="/project/:id" element={<Project />} loader={userProjectIdLoader} />
       <Route path="/user_project/:id" element={<Guidance />} loader={userProjectLoader}/>
     </Route>

--- a/src/components/recommendation/chat/Chat.jsx
+++ b/src/components/recommendation/chat/Chat.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import Breadcrumbs from './Breadcrumbs'
 import ChatInput from './ChatInput'
 import Question from './Question'
@@ -32,21 +32,31 @@ const recommendationChatSample =
 
 function Chat ({ recommendationChatId, setCurrIterationIndex }) {
   const [iterations, setIterations] = useState([])
+  const [iterationsLength, setIterationsLength] = useState(0)
   const [isLoading, setIsLoading] = useState(true)
   const [isAwaitingResponse, setIsAwaitingResponse] = useState(false)
-  const [currIterationIndex, setIterationIndex] = useState(0)
-
+  const isMounted = useRef(true)
+  useEffect(() => {
+    isMounted.current = true
+    return () => { isMounted.current = false }
+  }, [recommendationChatId])
+  useEffect(() => {
+    setIterationsLength(iterations.length)
+  }, [iterations])
+  useEffect(() => {
+    setCurrIterationIndex(iterationsLength - 1)
+  }, [iterationsLength])
   // Derive from iterations
   const currIteration = iterations.length ? iterations?.[iterations.length - 1] : null
   const breadcrumbs = iterations?.map(message => message.breadcrumb)
-
   // Retrieve iterations using API
   useEffect(() => {
     console.log(recommendationChatId)
     fetchRecommendationChat(recommendationChatId)
   }, [recommendationChatId])
-
-  useEffect(() => setCurrIterationIndex(currIterationIndex), [currIterationIndex])
+  useEffect(() => {
+    fetchSuggestionsAndBreadcrumb(recommendationChatId, iterationsLength - 1)
+  }, [recommendationChatId, iterationsLength])
   const navigate = useNavigate()
 
   const navigateToIteration = async (iterationIndex) => {
@@ -54,52 +64,89 @@ function Chat ({ recommendationChatId, setCurrIterationIndex }) {
     navigate(`/${newRecommendationChatId}`)
   }
 
-  const sendTextMessage = async (message) => {
-    setIsAwaitingResponse(true)
-    const {
-      data: {
-        text: response, emote: emotion, breadcrumb_title: breadcrumb, user_options: suggestions
-      }
-    } = await API.sendDiscoverageChatMessage(recommendationChatId, message)
-    const iteration = {
-      response,
-      emotion,
-      breadcrumb,
-      suggestions,
-      message
-    }
-    setIterations((iterations) => [...iterations, iteration])
-    setIterationIndex(i => i + 1)
-    setIsAwaitingResponse(false)
-  }
+  // const sendTextMessage = async (message) => {
+  //   setIsAwaitingResponse(true)
+  //   const {
+  //     data: {
+  //       text: response, breadcrumb_title: breadcrumb, user_options: suggestions
+  //     }
+  //   } = await API.sendDiscoverageChatMessage(recommendationChatId, message)
+  //   const iteration = {
+  //     response,
+  //     breadcrumb,
+  //     suggestions,
+  //     message
+  //   }
+  //   setIterations((iterations) => [...iterations, iteration])
+  //   setIterationIndex(i => i + 1)
+  //   setIsAwaitingResponse(false)
+  // }
   const sendAudioMessage = (blob) => {
-    setIterationIndex(i => i + 1)
+    // setIterationIndex(i => i + 1)
   }
-  //   class AIMessage(BaseModel):
-  //   role: str = Field(default="assistant")
-  //   content: str
-  //   emote: EmoteOption = Field(default="neutral")
 
-  // class UserMessage(BaseModel):
-  //   role: str = Field(default="user")
-  //   content: str
+  const updateIteration = (iterationIndex, field, modifier) => {
+    setIterations(prevIterations => {
+      if (prevIterations.length <= iterationIndex) {
+        return prevIterations
+      }
+      return [...prevIterations.slice(0, iterationIndex), {
+        ...prevIterations[iterationIndex],
+        [field]: modifier(prevIterations[iterationIndex][field])
+      }, ...prevIterations.slice(iterationIndex + 1)]
+    })
+  }
 
-  // class UserOption(BaseModel):
-  //   title: str
-  //   description: str
+  const fetchSuggestionsAndBreadcrumb = async (queryRecommendationChatId, iterationIndex) => {
+    if (!isMounted.current) {
+      return
+    }
+    if (recommendationChatId !== queryRecommendationChatId || iterationIndex <= 0 || iterations.length <= iterationIndex || (iterations[iterationIndex]?.suggestions.length && iterations[iterationIndex]?.breadcrumb)) {
+      return
+    }
+    const { data: { is_section_registered: isReady, suggestions, breadcrumb } } = await API.getDiscoveryChatSuggestionsAndBreadCrumb(queryRecommendationChatId, iterationIndex)
+    if (isReady) {
+      updateIteration(iterationIndex, 'suggestions', (_) => suggestions)
+      updateIteration(iterationIndex, 'breadcrumb', (_) => breadcrumb)
+    } else {
+      setTimeout(() => fetchSuggestionsAndBreadcrumb(queryRecommendationChatId, iterationIndex), 2000)
+    }
+  }
+  const fetchAIResponse = async (message) => {
+    try {
+      const iterationIndex = iterations.length - 1
+      setIterations(prevIterations => [...prevIterations, { response: '', breadcrumb: '...', suggestions: [], message: '' }])
+      const response = await fetch(API._constructUrl(`/api/discovery_chats/${recommendationChatId}/messages/${iterationIndex}`), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ message })
+      })
+      const reader = response.body.getReader()
 
-  // class DiscoveryChatSection(BaseModel):
-  //   title: str
-  //   ai_message: AIMessage
-  //   user_message: UserMessage | None = None
-  //   user_options: list[UserOption] | None = None
+      const decoder = new TextDecoder()
+
+      reader.read().then(function processText ({ done, value }) {
+        if (done) {
+          return
+        }
+        const responseText = decoder.decode(value)
+
+        updateIteration(iterationIndex + 1, 'response', (prevResponse) => (prevResponse ?? '') + responseText)
+
+        return reader.read().then(processText)
+      })
+    } catch (error) {
+      console.error('Error fetching data:', error)
+    }
+  }
   const fetchRecommendationChat = async (id) => {
     setIsLoading(true)
     const { data: messages } = await API.getDiscoveryChat(id)
-    const iterations = messages.map(({ title: breadcrumb, ai_message: { content: response, emote: emotion }, user_message: message, user_options: suggestions }) => ({
-      breadcrumb,
+    const iterations = messages.map(({ title: breadcrumb, ai_message: { content: response }, user_message: message, user_options: suggestions }) => ({
+      breadcrumb: breadcrumb ?? '...',
       response,
-      emotion,
       message: message?.content ?? '',
       suggestions: suggestions ?? []
     })
@@ -109,28 +156,28 @@ function Chat ({ recommendationChatId, setCurrIterationIndex }) {
   }
 
   return (
-    <div className="flex flex-col p-4 w-1/3 min-w-fit h-full bg-gray-200">
+    <div className="flex flex-col flex-grow-0 p-4 w-1/3 h-full bg-gray-200">
       {
         isLoading || !iterations.length
           ? <ClipLoader isLoading={isLoading || !iterations.length} />
           : (
             <>
-              <div>
-                <div className="flex-0 h-30 mb-4">
+            <div className="h-30 mb-4">
                   <Breadcrumbs breadcrumbs={breadcrumbs} navigateToIteration={navigateToIteration} />
                 </div>
+              <div className='overflow-y-auto '>
                 <div className="items-center my-8">
-                  <Question question={isAwaitingResponse ? '...' : currIteration.response} emotion={isAwaitingResponse ? 'thinking' : currIteration.emotion} />
+                  <Question question={currIteration.response} />
                 </div>
               </div>
               <div className='mt-auto'>
                 <div className="flow-1 flow flow-col mt-auto">
                   {!isAwaitingResponse && currIteration.suggestions.map((suggestion, index) => (
-                    <Suggestion suggestion={suggestion} sendSuggestion={sendTextMessage} key={index} />
+                    <Suggestion suggestion={suggestion} sendSuggestion={fetchAIResponse} key={index} />
                   ))}
                 </div>
                 <div className="flex-0 h-30 mb-3">
-                  <ChatInput sendTextMessage={sendTextMessage} sendAudioMessage={sendAudioMessage} />
+                  <ChatInput sendTextMessage={fetchAIResponse} sendAudioMessage={sendAudioMessage} />
                 </div>
               </div>
             </>

--- a/src/components/recommendation/chat/Question.jsx
+++ b/src/components/recommendation/chat/Question.jsx
@@ -1,12 +1,13 @@
 import React from 'react'
+import ReactMarkdown from 'react-markdown'
 
 export default function Question ({ question, emotion }) {
   return (
     <div className="flex items-end justify-start">
       <img src="https://images.unsplash.com/photo-1590031905470-a1a1feacbb0b?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=facearea&amp;facepad=3&amp;w=144&amp;h=144" alt="My profile" className="w-10 h-10 rounded-full order-2" />
-      <div className="flex flex-col space-y-2 text-xs max-w-xs mx-2 order-2 items-end">
+      <div className="flex flex-col space-y-2 text-xs max-w-md mx-2 order-2 items-end">
         <span className="p-4 rounded-lg inline-block rounded-bl-none bg-blue-600 text-white text-lg">
-          {question}
+          <ReactMarkdown>{question}</ReactMarkdown>
         </span>
       </div>
     </div>

--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,9 @@ import reportWebVitals from './reportWebVitals'
 
 const root = ReactDOM.createRoot(document.getElementById('root'))
 root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+  // <React.StrictMode>
+  <App />
+  // </React.StrictMode>
 )
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -111,20 +111,24 @@ class APIClass {
     return axios.post(this._constructUrl(`/api/discovery_chats/${id}/messages`), { message })
   }
 
-  getRecommendedStaticProjects (discoveryChatId, offset = 0, limit = 5) {
-    return axios.get(this._constructUrl(`/api/projects/recommended/${discoveryChatId}`), { params: { offset, limit } })
+  getRecommendedStaticProjects (discoveryChatId, iterationIndex, offset = 0, limit = 5) {
+    return axios.get(this._constructUrl('/api/projects/recommended/static'), { params: { chat_id: discoveryChatId, section_index: iterationIndex, offset, limit } })
   }
 
-  getRecommendedDynamicProjects (discoveryChatId, count = 4) {
-    return axios.post(this._constructUrl('/api/projects/dynamic/metadata'), { chat_id: discoveryChatId, count })
+  getRecommendedDynamicProjects (discoveryChatId, iterationIndex, offset = 0, limit = 5) {
+    return axios.get(this._constructUrl('/api/projects/recommended/dynamic'), { params: { chat_id: discoveryChatId, section_index: iterationIndex, offset, limit } })
   }
 
-  getFilledDynamicProject (dynamicProjectMetadata) {
-    return axios.post(this._constructUrl('/api/projects/dynamic'), { ...dynamicProjectMetadata })
+  getFilledDynamicProject (metadataId) {
+    return axios.post(this._constructUrl(`/api/projects/dynamic/${metadataId}`))
   }
 
-  navigateToBreadcrumb (discoveryChatId, breadcrumbTitle) {
-    return axios.post(this._constructUrl(`/api/discovery_chats/${discoveryChatId}`), { section_title: breadcrumbTitle })
+  navigateToBreadcrumb (discoveryChatId, iterationIndex) {
+    return axios.post(this._constructUrl(`/api/discovery_chats/${discoveryChatId}/sections/${iterationIndex}`))
+  }
+
+  getDiscoveryChatSuggestionsAndBreadCrumb (discoveryChatId, iterationIndex) {
+    return axios.get(this._constructUrl(`/api/discovery_chats/${discoveryChatId}/suggestions_breadcrumbs/${iterationIndex}`))
   }
 }
 

--- a/src/pages/Guidance/DynamicProject.jsx
+++ b/src/pages/Guidance/DynamicProject.jsx
@@ -1,29 +1,23 @@
 import { API } from 'lib/utils'
 import React, { useEffect, useState } from 'react'
-import { Navigate, useLocation } from 'react-router-dom'
+import { Navigate, useParams } from 'react-router-dom'
 import { ClipLoader } from 'react-spinners'
 
 export default function DynamicProject () {
-  const { state: metadata } = useLocation()
+  const { id: metadataId } = useParams()
   const [userProjectId, setUserProjectId] = useState(null)
-  const fetchDynamicSearchResults = async (metadata) => {
-    // const { data: project } = await API.getFilledDynamicProject(metadata)
-    const { data: { user_project_id: userProjectIdFetched } } = await API.createDynamicUserProject('6541e7c2c52ca85608473c9a')
-    setUserProjectId(userProjectIdFetched)
+  const fetchAndSetUserProjectId = async (metadataId) => {
+    if (metadataId == null) {
+      return
+    }
+    const { data: { project_id: projectId } } = await API.getFilledDynamicProject(metadataId)
+    console.log('Created dynamic project', projectId)
+    const { data: { user_project_id: userProjectId } } = await API.createDynamicUserProject(projectId)
+    console.log('Created dynamic user project', userProjectId)
+    setUserProjectId(userProjectId)
   }
   useEffect(() => {
-    console.log('inside DynamicProject')
-    console.log(metadata)
-    fetchDynamicSearchResults(metadata)
-    // const { data: project } = await API.getFilledDynamicProject(metadata)
-    // const { data: { user_project_id: userProjectIdFetched } } = await API.getUserProject(project.project_id)
-    // setUserProjectId(userProjectIdFetched)
-  }, [metadata])
-  return (
-    userProjectId == null
-      ? <ClipLoader isLoading={userProjectId == null} />
-      : (
-        <Navigate to={`/user_project/${userProjectId}`} />
-        )
-  )
+    fetchAndSetUserProjectId(metadataId)
+  }, [metadataId])
+  return (userProjectId == null ? <ClipLoader isLoading={userProjectId == null} /> : <Navigate to={`/user_project/${userProjectId}`} />)
 }


### PR DESCRIPTION
## Refactor POST /api/projects/dynamic/metadata to also return metadata_id

1. Static: project_id -> createUserProject(project_id) -> user_project_id (navigated to the stage 2 with this id)
2. dynamic: metadata_id -> createDynamicProject(metadata_id) -> dynamic_project_id -> createUserProject(dynamic_project_id)  -> user_project_id (navigated to the stage 2 with this id)

## Discovery Chat is now streaming

## Refactor to split into 4 API calls to backend.

1. Refactor get_discovery_response to only return the response and nothing else, should be a stream as well
2. Create get_discovery_chat_suggestions,
3. Create static results endpoint
4. Create dynamic results endpoint
5. In filling full dynamic project, update metadata to point to full project. And pre check if full project exists, if so, then return it straight
6. Integrate with frontend
7. All search results are now cached per (discoveryChat, section)